### PR TITLE
연락처 서버와 비교하여 회원가입한 유저들 정보만 앱에 뿌려주는 기능 완성

### DIFF
--- a/app/src/main/java/com/capstone/belink/Model/ContactInfo.kt
+++ b/app/src/main/java/com/capstone/belink/Model/ContactInfo.kt
@@ -1,0 +1,5 @@
+package com.capstone.belink.Model
+
+data class ContactInfo(
+        val data:List<FriendUser>
+)

--- a/app/src/main/java/com/capstone/belink/Model/User.kt
+++ b/app/src/main/java/com/capstone/belink/Model/User.kt
@@ -10,5 +10,4 @@ data class User(val id:String="",
                 val infect:Int=0,
                 val createdAt: Date=Date(),
                 val updatedAt: Date=Date()
-
                 )

--- a/app/src/main/java/com/capstone/belink/Model/success.kt
+++ b/app/src/main/java/com/capstone/belink/Model/success.kt
@@ -1,5 +1,5 @@
 package com.capstone.belink.Model
 
 data class success (
-        val success:List<Int>
+        val success:Boolean
         )

--- a/app/src/main/java/com/capstone/belink/Network/RetrofitService.kt
+++ b/app/src/main/java/com/capstone/belink/Network/RetrofitService.kt
@@ -31,5 +31,9 @@ interface RetrofitService {
     @POST("api/user/edit-team")
     fun makeTeam(@Field("teamName")teamName:String):Call<Sign>
 
+    @FormUrlEncoded
+    @POST("api/user/contact-user")
+    fun contactUser(@Field("phNum")phNum:List<String>):Call<ContactInfo>
+
 
 }

--- a/app/src/main/java/com/capstone/belink/UIActivity/FriendSettingActivity.kt
+++ b/app/src/main/java/com/capstone/belink/UIActivity/FriendSettingActivity.kt
@@ -10,33 +10,85 @@ import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.capstone.belink.Model.ContactInfo
 import com.capstone.belink.Model.User
+import com.capstone.belink.Network.RetrofitClient
+import com.capstone.belink.Network.RetrofitService
 import com.capstone.belink.Utils.getStringArrayPref
 import com.capstone.belink.Utils.setStringArrayPref
 import com.capstone.belink.databinding.ActivityFriendSettingBinding
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
 
 
 class FriendSettingActivity : AppCompatActivity() {
+
     private var mBinding:ActivityFriendSettingBinding?=null
     private val binding get() = mBinding!!
+
+
+
+    private lateinit var retrofit: Retrofit
+    private lateinit var supplementService: RetrofitService
+
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mBinding= ActivityFriendSettingBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
+        initRetrofit()
 
 
         binding.tvFriendReadContact.setOnClickListener {
             getContact()
-        }
+            val contactUser=getStringArrayPref(this,"contact")
+            println("map.isEmpty() is ${contactUser.isEmpty()}")
+            println("           contactUser.keys is ${contactUser.keys}")
+            val phNumList=contactUser.keys
+            println("           phNumList is $phNumList")
+            val userList:MutableList<User> = ArrayList()
+            supplementService.contactUser(phNumList.toList()).enqueue(object :Callback<ContactInfo>{
+                override fun onResponse(call: Call<ContactInfo>, response: Response<ContactInfo>) {
+                    val data = response.body()?.data
+                    println("pass the response")
+                    println("${response.body()?.data}")
+                    if(data!=null){
+                        for(i in data.indices){
+                            println("pass the for loop")
+                            val id = data[i].id
+                            val username = data[i].username
+                            val phNum = data[i].phNum
+                            println("$id  $username   $phNum")
+                            userList.add(User(id=id,username=username,phNum = phNum))
+                        }
+                    }
+                    setStringArrayPref((this@FriendSettingActivity),"contact",userList)
 
+                }
+
+                override fun onFailure(call: Call<ContactInfo>, t: Throwable) {
+                    Log.d("fail","$t")
+                }
+
+            })
+        }
         binding.btnGetContact.setOnClickListener {
             getStringArrayPref(this,"contact")
         }
+
+    }
+
+
+
+    private fun initRetrofit() {
+        retrofit = RetrofitClient.getInstance()
+        supplementService = retrofit.create(RetrofitService::class.java)
     }
 
     fun readContacts(view: View){

--- a/app/src/main/java/com/capstone/belink/Ui/FragmentFriend.kt
+++ b/app/src/main/java/com/capstone/belink/Ui/FragmentFriend.kt
@@ -16,6 +16,7 @@ import com.capstone.belink.Model.FriendUser
 import com.capstone.belink.Network.RetrofitClient
 import com.capstone.belink.Network.RetrofitService
 import com.capstone.belink.UIActivity.TeamActivity
+import com.capstone.belink.Utils.getStringArrayPref
 import com.capstone.belink.databinding.FragmentFriendBinding
 import retrofit2.Call
 import retrofit2.Callback
@@ -36,7 +37,7 @@ class FragmentFriend:Fragment() {
     private lateinit var auto: SharedPreferences
     private lateinit var autoLogin: SharedPreferences.Editor
 
-
+    private lateinit var contactUser: HashMap<String,String>
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         mBinding = FragmentFriendBinding.inflate(inflater,container,false)
@@ -44,8 +45,11 @@ class FragmentFriend:Fragment() {
 
         auto =(activity as TeamActivity).getSharedPreferences("auto", Activity.MODE_PRIVATE)
         autoLogin=auto.edit()
+
         initRetrofit()
         init()
+
+
 
         return view
     }

--- a/app/src/main/java/com/capstone/belink/Utils/ContactInfo.kt
+++ b/app/src/main/java/com/capstone/belink/Utils/ContactInfo.kt
@@ -18,6 +18,7 @@ fun setStringArrayPref(context: Context,key:String,values:MutableList<User>){
         val tempJsonObject = JSONObject()
         Log.d("이름","${values[i].username}")
         Log.d("전화번호","${values[i].phNum}")
+        tempJsonObject.put("id",values[i].id)
         tempJsonObject.put("username",values[i].username)
         tempJsonObject.put("phNum",values[i].phNum)
         dataList.put(tempJsonObject)
@@ -30,11 +31,12 @@ fun setStringArrayPref(context: Context,key:String,values:MutableList<User>){
     edit.apply()
 }
 
-fun getStringArrayPref(context: Context,key:String):MutableList<User>{
+fun getStringArrayPref(context: Context,key:String):HashMap<String,String>{
     val pref: SharedPreferences =context.getSharedPreferences(key, AppCompatActivity.MODE_PRIVATE)
     val edit: SharedPreferences.Editor = pref.edit()
     val json=pref.getString(key,null)
-    var uri : MutableList<User> = ArrayList()
+    var uri : HashMap<String,String> = HashMap()
+    Log.d("getStringArrayPref","확인")
     if(json != null){
         try{
             val temp = JSONArray(json)
@@ -43,13 +45,14 @@ fun getStringArrayPref(context: Context,key:String):MutableList<User>{
                 val username = iObject.getString("username")
                 val phNum = iObject.getString("phNum")
                 val obj = User(username=username,phNum = phNum)
-                uri.add(obj)
+                uri[phNum]=username
                 Log.d("$phNum","$username")
             }
         }catch (e: JSONException){
             e.printStackTrace()
         }
     }
+    Log.d("uri 값 확인",uri.toString())
     return uri
 
 


### PR DESCRIPTION
우선 연락처의 정보를 가져온 다음에 서버와 http통신을 통해 해당 전화번호를 가진 사람이 이 앱을 사용하는 지 확인하고 나서
사용한 사람의 유저정보들을 가져온 다음 json형식으로 앱에 저장하는 로직을 구성했다.